### PR TITLE
Add configurable test framework option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ sonar.test.inclusions=**/*.spec.ts
 
 sonar.ruby.file.suffixes=rb,ruby
 sonar.ruby.coverage.reportPath=coverage/.resultset.json
+sonar.ruby.coverage.framework=RSpec
 sonar.ruby.rubocopConfig=.rubocop.yml
 sonar.ruby.rubocop=/usr/bin/rubocop
 sonar.ruby.rubocop.reportPath=rubocop-result.json

--- a/src/main/java/com/fortitudetec/sonar/plugins/ruby/RubyPlugin.java
+++ b/src/main/java/com/fortitudetec/sonar/plugins/ruby/RubyPlugin.java
@@ -23,6 +23,7 @@ public class RubyPlugin implements Plugin {
     // Properties
     public static final String FILE_SUFFIXES = "sonar.ruby.file.suffixes";
     public static final String SIMPLECOV_REPORT_PATH = "sonar.ruby.coverage.reportPath";
+    public static final String TEST_FRAMEWORK = "sonar.ruby.coverage.framework";
     public static final String RUBOCOP_CONFIG = "sonar.ruby.rubocopConfig";
     public static final String RUBOCOP_BIN = "sonar.ruby.rubocop";
     public static final String RUBOCOP_REPORT_PATH = "sonar.ruby.rubocop.reportPath";
@@ -48,6 +49,15 @@ public class RubyPlugin implements Plugin {
                 .subCategory(TEST_AND_COVERAGE)
                 .onQualifiers(Qualifiers.PROJECT)
                 .defaultValue("coverage/.resultset.json")
+                .build(),
+
+            PropertyDefinition.builder(TEST_FRAMEWORK)
+                .name("Name of test framework")
+                .description("Name of test framework.")
+                .category(RUBY_CATEGORY)
+                .subCategory(TEST_AND_COVERAGE)
+                .onQualifiers(Qualifiers.PROJECT)
+                .defaultValue("RSpec")
                 .build(),
 
             // RUBOCOP

--- a/src/main/java/com/fortitudetec/sonar/plugins/ruby/simplecov/SimpleCovParser.java
+++ b/src/main/java/com/fortitudetec/sonar/plugins/ruby/simplecov/SimpleCovParser.java
@@ -1,9 +1,11 @@
 package com.fortitudetec.sonar.plugins.ruby.simplecov;
 
 import static java.util.Objects.nonNull;
+import static java.util.Objects.isNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fortitudetec.sonar.plugins.ruby.Ruby;
+import com.fortitudetec.sonar.plugins.ruby.RubyPlugin;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -38,8 +40,14 @@ public class SimpleCovParser {
 
         Map<String, Map<String, Map<String, List<Integer>>>> results = parseResultsFile(resultFile);
 
-        // TODO: Simplecov works with more than Rspec, need to make this configurable
-        Map<String, List<Integer>> coverageByFile = results.get("RSpec").get("coverage");
+        String testFramework = ctx.settings().getString(RubyPlugin.TEST_FRAMEWORK);
+
+        if (isNull(testFramework)) {
+            LOG.warn("Test framework is not set, unable to parse coverage metrics");
+            return null;
+        }
+
+        Map<String, List<Integer>> coverageByFile = results.get(testFramework).get("coverage");
 
         Iterable<InputFile> inputFiles = ctx.fileSystem().inputFiles(ctx.fileSystem().predicates().hasLanguage(Ruby.LANGUAGE_KEY));
 

--- a/src/test/java/com/fortitudetec/sonar/plugins/ruby/RubyPluginTest.java
+++ b/src/test/java/com/fortitudetec/sonar/plugins/ruby/RubyPluginTest.java
@@ -18,9 +18,9 @@ public class RubyPluginTest {
 
         plugin.define(context);
 
-        assertThat(context.getExtensions().size()).isEqualTo(17);
+        assertThat(context.getExtensions().size()).isEqualTo(18);
 
-        assertThat(context.getExtensions().stream().filter(ext -> ext instanceof PropertyDefinition).count()).isEqualTo(6);
+        assertThat(context.getExtensions().stream().filter(ext -> ext instanceof PropertyDefinition).count()).isEqualTo(7);
         assertThat(context.getExtensions().stream().filter(ext -> ext instanceof Class).count()).isEqualTo(11);
     }
 }


### PR DESCRIPTION
I would like to add a test framework option since SimpleCov supports other frameworks like MiniTest. It currently fails if you're not using RSpec.